### PR TITLE
Adds Dockerfile and first version of pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,17 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build TaskChampion Sync-Server
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - tag: amd64-musl
+            target: x86_64-unknown-linux-musl
+            test: false
+          - tag: amd64-glibc
+            target: x86_64-unknown-linux-gnu
+            test: true
+    name: Build TaskChampion Sync-Server ${{ matrix.target.tag }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -13,35 +23,39 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.77
+          targets: ${{ matrix.target.target }}
       - name: Test
+        if: ${{ matrix.target.test }}
         run: cargo test
       - name: Build
-        run: cargo build --release --locked
+        run: |
+          [ "${{ matrix.target.target }}" == "x86_64-unknown-linux-musl" ] && sudo apt update && sudo apt -y install musl-tools
+          cargo build --target ${{ matrix.target.target }} --release --locked
       - name: Package current compilation
         id: package-current
         run: |
-          install -Dm755 "target/release/taskchampion-sync-server" "taskchampion-sync-server-${GITHUB_REF##*/}-${GITHUB_SHA}/taskchampion-sync-server"
-          install -Dm644 "README.md" "taskchampion-sync-server-${GITHUB_REF##*/}-${GITHUB_SHA}/README.md"
-          install -Dm644 "LICENSE" "taskchampion-sync-server-${GITHUB_REF##*/}-${GITHUB_SHA}/LICENSE"
+          install -Dm755 "target/${{ matrix.target.target }}/release/taskchampion-sync-server" "taskchampion-sync-server-${{ matrix.target.tag }}-${GITHUB_REF##*/}-${GITHUB_SHA}/taskchampion-sync-server"
+          install -Dm644 "README.md" "taskchampion-sync-server-${{ matrix.target.tag }}-${GITHUB_REF##*/}-${GITHUB_SHA}/README.md"
+          install -Dm644 "LICENSE" "taskchampion-sync-server-${{ matrix.target.tag }}-${GITHUB_REF##*/}-${GITHUB_SHA}/LICENSE"
           echo "version=${GITHUB_REF##*/}-${GITHUB_SHA}" >> $GITHUB_OUTPUT
       - name: Archive current compilation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: "taskchampion-sync-server-${{ steps.package-current.outputs.version }}"
-          path: "taskchampion-sync-server-${{ steps.package-current.outputs.version }}/"
+          name: "taskchampion-sync-server-${{ matrix.target.tag }}-${{ steps.package-current.outputs.version }}"
+          path: "taskchampion-sync-server-${{ matrix.target.tag }}-${{ steps.package-current.outputs.version }}/"
       - name: Package tagged compilation
         id: package
         if: startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request'
         run: |
-          install -Dm755 "target/release/taskchampion-sync-server" "taskchampion-sync-server-${GITHUB_REF##*/}/taskchampion-sync-server"
-          install -Dm644 "README.md" "taskchampion-sync-server-${GITHUB_REF##*/}/README.md"
-          install -Dm644 "LICENSE" "taskchampion-sync-server-${GITHUB_REF##*/}/LICENSE"
-          tar cvJf "taskchampion-sync-server-${GITHUB_REF##*/}.tar.xz" "taskchampion-sync-server-${GITHUB_REF##*/}"
+          install -Dm755 "target/${{ matrix.target.target }}/release/taskchampion-sync-server" "taskchampion-sync-server-${{ matrix.target.tag }}-${GITHUB_REF##*/}/taskchampion-sync-server"
+          install -Dm644 "README.md" "taskchampion-sync-server-${{ matrix.target.tag }}-${GITHUB_REF##*/}/README.md"
+          install -Dm644 "LICENSE" "taskchampion-sync-server-${{ matrix.target.tag }}-${GITHUB_REF##*/}/LICENSE"
+          tar cvJf "taskchampion-sync-server-${{ matrix.target.tag }}-${GITHUB_REF##*/}.tar.xz" "taskchampion-sync-server-${{ matrix.target.tag }}-${GITHUB_REF##*/}"
           echo "version=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request'
         with:
-          files: "taskchampion-sync-server-${{ steps.package.outputs.version }}.tar.xz"
+          files: "taskchampion-sync-server-${{ matrix.target.tag }}-${{ steps.package.outputs.version }}.tar.xz"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build TaskChampion Sync-Server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.77
+      - name: Test
+        run: cargo test
+      - name: Build
+        run: cargo build --release --locked
+      - name: Package current compilation
+        id: package-current
+        run: |
+          install -Dm755 "target/release/taskchampion-sync-server" "taskchampion-sync-server-${GITHUB_REF##*/}-${GITHUB_SHA}/taskchampion-sync-server"
+          install -Dm644 "README.md" "taskchampion-sync-server-${GITHUB_REF##*/}-${GITHUB_SHA}/README.md"
+          install -Dm644 "LICENSE" "taskchampion-sync-server-${GITHUB_REF##*/}-${GITHUB_SHA}/LICENSE"
+          echo "version=${GITHUB_REF##*/}-${GITHUB_SHA}" >> $GITHUB_OUTPUT
+      - name: Archive current compilation
+        uses: actions/upload-artifact@v3
+        with:
+          name: "taskchampion-sync-server-${{ steps.package-current.outputs.version }}"
+          path: "taskchampion-sync-server-${{ steps.package-current.outputs.version }}/"
+      - name: Package tagged compilation
+        id: package
+        if: startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request'
+        run: |
+          install -Dm755 "target/release/taskchampion-sync-server" "taskchampion-sync-server-${GITHUB_REF##*/}/taskchampion-sync-server"
+          install -Dm644 "README.md" "taskchampion-sync-server-${GITHUB_REF##*/}/README.md"
+          install -Dm644 "LICENSE" "taskchampion-sync-server-${GITHUB_REF##*/}/LICENSE"
+          tar cvJf "taskchampion-sync-server-${GITHUB_REF##*/}.tar.xz" "taskchampion-sync-server-${GITHUB_REF##*/}"
+          echo "version=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request'
+        with:
+          files: "taskchampion-sync-server-${{ steps.package.outputs.version }}.tar.xz"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Build Docker
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=match,pattern=\d.\d.\d,value=latest
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
+      - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Versions must be major.minor
+ARG RUST_VERSION=1.77
+ARG ALPINE_VERSION=3.19
+
+FROM docker.io/rust:${RUST_VERSION}-alpine${ALPINE_VERSION} AS builder
+COPY . /data
+RUN apk -U add libc-dev && \
+  cd /data && \
+  cargo build --release
+
+FROM docker.io/alpine:${ALPINE_VERSION}
+COPY --from=builder /data/target/release/taskchampion-sync-server /bin
+RUN adduser -S -D -H -h /var/lib/taskchampion-sync-server -s /sbin/nologin -G users \
+  -g taskchampion taskchampion && \
+  install -d -m755 -o100 -g100 "/var/lib/taskchampion-sync-server"
+EXPOSE 8080
+VOLUME "/var/lib/taskchampion-sync-server"
+USER taskchampion
+ENTRYPOINT [ "taskchampion-sync-server" ]


### PR DESCRIPTION
This uploads the container to the GitHub hub as a package. Tag it with either tag in tagged versions (using semver) or the branch name in the rest.

The image is created for both x64 and ARM64 (takes about 40 minutes to compile for ARM64).

With the `build.yml` pipeline it simply compile the binary and save it as an artifact. If a tag is created, it uploads the artifact to the tag as tar.xz.