### PR TITLE
Provide more context on mkdir failures

### DIFF
--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -42,7 +42,8 @@ impl SqliteStorage {
     }
 
     pub fn new<P: AsRef<Path>>(directory: P) -> anyhow::Result<SqliteStorage> {
-        std::fs::create_dir_all(&directory)?;
+        std::fs::create_dir_all(&directory)
+            .with_context(|| format!("Failed to create `{}`.", directory.as_ref().display()))?;
         let db_file = directory.as_ref().join("taskchampion-sync-server.sqlite3");
 
         let o = SqliteStorage { db_file };


### PR DESCRIPTION
For example, instead of:

```
Error: Permission denied (os error 13)
```

one will get:

```
Error: Failed to create `/var/lib/taskchampion-sync-server`.

Caused by:
    Permission denied (os error 13)
```

after this patch is applied.