### PR TITLE
Remove references to release binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ It is comprised of three crates:
 
 ## Installation
 
-### From binary
-
-Simply download latest release from [releases page][releases].
-
-[releases]: https://github.com/GothenburgBitFactory/taskchampion-sync-server/releases
-
 ### As container
 
 To build the container execute the following commands.


### PR DESCRIPTION
These don't exist, and the remainder of the README instructions are sufficient.

@ogarcia did a great job with the instructions. I don't think we need to get involved with building binaries for download.