### PR TITLE
Improve error handling in the inmemory storage implementation.

### DIFF
--- a/sqlite/src/lib.rs
+++ b/sqlite/src/lib.rs
@@ -386,6 +386,23 @@ mod test {
     }
 
     #[test]
+    fn test_add_version_exists() -> anyhow::Result<()> {
+        let tmp_dir = TempDir::new()?;
+        let storage = SqliteStorage::new(tmp_dir.path())?;
+        let client_id = Uuid::new_v4();
+        let mut txn = storage.txn(client_id)?;
+
+        let version_id = Uuid::new_v4();
+        let parent_version_id = Uuid::new_v4();
+        let history_segment = b"abc".to_vec();
+        txn.add_version(version_id, parent_version_id, history_segment.clone())?;
+        assert!(txn
+            .add_version(version_id, parent_version_id, history_segment.clone())
+            .is_err());
+        Ok(())
+    }
+
+    #[test]
     fn test_snapshots() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new()?;
         let storage = SqliteStorage::new(tmp_dir.path())?;


### PR DESCRIPTION
This addresses a TODO, in a type that is really only used for testing.

This also adds a test for a similar circumstance -- adding the same version twice -- in the SQLite storage. That circumstance is already handled correctly.