### PR TITLE
Customize Listen Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ system startup. See the docker-compose documentation for more information.
 The server is configured with command-line options. See
 `taskchampion-sync-server --help` for full details.
 
-The `--data-dir` option specifies where the server should store its data, and
-`--port` gives the port on which the HTTP server runs.
+The `--listen` option specifies the interface and port the server listens on.
+It must contain an IP-Address or a DNS name and a port number. This option is
+mandatory, but can be repeated to specify multiple interfaces or ports.
+
+The `--data-dir` option specifies where the server should store its data.
 
 By default, the server allows all client IDs. To limit the accepted client IDs,
 such as when running a personal server, use `--allow-client-id <client-id>`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
         volume:
           nocopy: true
           subpath: tss
-    command: --data-dir /tss/taskchampion-sync-server --port 8080
+    command: --data-dir /tss/taskchampion-sync-server --listen 0.0.0.0:8080
     environment:
       - RUST_LOG=info
     depends_on:


### PR DESCRIPTION
This allows to specify the listen address on the cli. I Have also changed the default to localhost because in my opinion the default should never be 0.0.0.0. But I will change it back if necessary.

I have also narrowed the data type for the port from usize to u16. This change slightly improves the error message if an out of range port number is specified