### PR TITLE
Use version-specific references for docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,18 @@ Every release of the server generates a Docker image in
 `latest` for the latest release, and both minor and patch versions, e.g., `0.5`
 and `0.5.1`.
 
-The [`docker-compose.yml`](./docker-compose.yml) file in this repository is
-sufficient to run taskchampion-sync-server, including setting up TLS
-certificates using Lets Encrypt, thanks to [Caddy](https://caddyserver.com/).
+The
+[`docker-compose.yml`](https://raw.githubusercontent.com/GothenburgBitFactory/taskchampion-sync-server/refs/tags/v0.5.0/docker-compose.yml)
+file in this repository is sufficient to run taskchampion-sync-server,
+including setting up TLS certificates using Lets Encrypt, thanks to
+[Caddy](https://caddyserver.com/).
 
 You will need a server with ports 80 and 443 open to the Internet and with a
 fixed, publicly-resolvable hostname. These ports must be available both to your
 Taskwarrior clients and to the Lets Encrypt servers.
 
-On that server, clone this repository (or just download `docker-compose.yml` to
-the current directory -- the rest of the contents of this repository are not
-required) and run
+On that server, download `docker-compose.yml` from the link above (it is pinned
+to the latest release) into the current directory. Then run
 
 ```sh
 TASKCHAMPION_SYNC_SERVER_HOSTNAME=taskwarrior.example.com docker compose up

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,8 @@
 1. Run `cargo test`
 1. Run `cargo clean && cargo clippy`
 1. Remove the `-pre` from `version` in all `*/Cargo.toml`, and from the `version = ..` in any references between packages.
+1. Update the link to `docker-compose.yml` in `README.md` to refer to the new version.
+1. Update the docker image in `docker-compose.yml` to refer to the new version.
 1. Run `cargo semver-checks` (https://crates.io/crates/cargo-semver-checks)
 1. Run `cargo build --release`
 1. Commit the changes (Cargo.lock will change too) with comment `vX.Y.Z`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         condition: service_completed_successfully
 
   tss:
-    image: ghcr.io/gothenburgbitfactory/taskchampion-sync-server:latest
+    image: ghcr.io/gothenburgbitfactory/taskchampion-sync-server:0.5.0
     restart: unless-stopped
     volumes:
       - type: volume


### PR DESCRIPTION
This makes the README refer to the latest release's `docker-compose.yml`, and makes `docker-compose.yml` refer to a versioned docker image.

Fixes #84.