### PR TITLE
Fix clap error

### DIFF
--- a/server/src/bin/taskchampion-sync-server.rs
+++ b/server/src/bin/taskchampion-sync-server.rs
@@ -88,7 +88,7 @@ async fn main() -> anyhow::Result<()> {
             .wrap(Logger::default())
             .configure(|cfg| server.config(cfg))
     });
-    for listen_address in matches.get_many::<&str>("listen").unwrap() {
+    for listen_address in matches.get_many::<String>("listen").unwrap() {
         log::info!("Serving on {}", listen_address);
         http_server = http_server.bind(listen_address)?
     }


### PR DESCRIPTION
At tip of main (time of writing: 47978bf), running `taskchampion-sync-server --listen 8080 -d .` causes a panic with `Mismatch between definition and access of \`listen\`. Could not downcast to &str, need to downcast to alloc::string::String`. This PR fixes this.