### PR TITLE
feat(docker): simplify docker compose for end users

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*
+!Cargo.toml
+!Cargo.lock
+!core/
+!server/
+!sqlite/
+!docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,25 @@
 # Versions must be major.minor
-ARG RUST_VERSION
-ARG ALPINE_VERSION
+# Default versions are as below
+ARG RUST_VERSION=1.78
+ARG ALPINE_VERSION=3.19
 
 FROM docker.io/rust:${RUST_VERSION}-alpine${ALPINE_VERSION} AS builder
-COPY . /data
+COPY Cargo.lock Cargo.toml /data/
+COPY core /data/core/
+COPY server /data/server/
+COPY sqlite /data/sqlite/
 RUN apk -U add libc-dev && \
   cd /data && \
   cargo build --release
 
 FROM docker.io/alpine:${ALPINE_VERSION}
 COPY --from=builder /data/target/release/taskchampion-sync-server /bin
-RUN adduser -S -D -H -h /var/lib/taskchampion-sync-server -s /sbin/nologin -G users \
+RUN apk add --no-cache su-exec && \
+  adduser -u 100 -S -D -H -h /var/lib/taskchampion-sync-server -s /sbin/nologin -G users \
   -g taskchampion taskchampion && \
-  install -d -m755 -o100 -g100 "/var/lib/taskchampion-sync-server"
+  install -d -m1755 -o100 -g100 "/var/lib/taskchampion-sync-server"
 EXPOSE 8080
-VOLUME "/var/lib/taskchampion-sync-server"
-USER taskchampion
-ENTRYPOINT [ "taskchampion-sync-server" ]
+VOLUME /var/lib/task-champion-sync-server/data
+COPY docker-entrypoint.sh /bin
+ENTRYPOINT [ "/bin/docker-entrypoint.sh" ]
+CMD [ "/bin/taskchampion-sync-server" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN apk -U add libc-dev && \
 FROM docker.io/alpine:${ALPINE_VERSION}
 COPY --from=builder /data/target/release/taskchampion-sync-server /bin
 RUN apk add --no-cache su-exec && \
-  adduser -u 100 -S -D -H -h /var/lib/taskchampion-sync-server -s /sbin/nologin -G users \
+  adduser -u 1092 -S -D -H -h /var/lib/taskchampion-sync-server -s /sbin/nologin -G users \
   -g taskchampion taskchampion && \
-  install -d -m1755 -o100 -g100 "/var/lib/taskchampion-sync-server"
+  install -d -m1755 -o1092 -g1092 "/var/lib/taskchampion-sync-server"
 EXPOSE 8080
 VOLUME /var/lib/task-champion-sync-server/data
 COPY docker-entrypoint.sh /bin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,4 @@
-volumes:
-  data:
-
 services:
-  # Make the necessary subdirectories of the `data` volume, and set ownership of the
-  # `tss/taskchampion-sync-server` directory, as the server runs as user 100.
-  mkdir:
-    image: caddy:2-alpine
-    command: |
-      /bin/sh -c "
-        mkdir -p /data/caddy/data /data/caddy/config /data/tss/taskchampion-sync-server &&
-        chown -R 100:100 /data/tss/taskchampion-sync-server
-      "
-    volumes:
-      - type: volume
-        source: data
-        target: /data
-        read_only: false
-        volume:
-          nocopy: true
-
   caddy:
     image: caddy:2-alpine
     restart: unless-stopped
@@ -26,40 +6,17 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - type: volume
-        source: data
-        target: /data
-        read_only: false
-        volume:
-          nocopy: true
-          subpath: caddy/data
-      - type: volume
-        source: data
-        target: /config
-        read_only: false
-        volume:
-          nocopy: true
-          subpath: caddy/config
+      - /srv/caddy/data:/data
+      - /srv/caddy/config:/config
     command: caddy reverse-proxy --from https://${TASKCHAMPION_SYNC_SERVER_HOSTNAME} --to http://tss:8080
     depends_on:
-      mkdir:
-        condition: service_completed_successfully
-
+      - tss
   tss:
     image: ghcr.io/gothenburgbitfactory/taskchampion-sync-server:0.5.0
     restart: unless-stopped
     volumes:
-      - type: volume
-        source: data
-        target: /tss
-        read_only: false
-        volume:
-          nocopy: true
-          subpath: tss
+      - /srv/taskchampion-sync-server:/var/lib/taskchampion-sync-server/data
     environment:
       - "RUST_LOG=info"
-      - "DATA_DIR=/tss/taskchampion-sync-server"
+      - "DATA_DIR=/var/lib/taskchampion-sync-server/data"
       - "LISTEN=0.0.0.0:8080"
-    depends_on:
-      mkdir:
-        condition: service_completed_successfully

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+volumes:
+  data:
+
+
 services:
   caddy:
     image: caddy:2-alpine
@@ -6,17 +10,35 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /srv/caddy/data:/data
-      - /srv/caddy/config:/config
+      - type: volume
+        source: data
+        target: /data
+        read_only: false
+        volume:
+          nocopy: true
+          subpath: caddy/data
+      - type: volume
+        source: data
+        target: /config
+        read_only: false
+        volume:
+          nocopy: true
+          subpath: caddy/config
     command: caddy reverse-proxy --from https://${TASKCHAMPION_SYNC_SERVER_HOSTNAME} --to http://tss:8080
     depends_on:
       - tss
   tss:
     image: ghcr.io/gothenburgbitfactory/taskchampion-sync-server:0.5.0
     restart: unless-stopped
-    volumes:
-      - /srv/taskchampion-sync-server:/var/lib/taskchampion-sync-server/data
     environment:
       - "RUST_LOG=info"
       - "DATA_DIR=/var/lib/taskchampion-sync-server/data"
       - "LISTEN=0.0.0.0:8080"
+    volumes:
+      - type: volume
+        source: data
+        target: /var/lib/taskchampion-sync-server/data
+        read_only: false
+        volume:
+          nocopy: true
+          subpath: tss/taskchampion-sync-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
         volume:
           nocopy: true
           subpath: caddy/config
-    command: caddy reverse-proxy --from http://${TASKCHAMPION_SYNC_SERVER_HOSTNAME} --to http://tss:8080
+    command: caddy reverse-proxy --from https://${TASKCHAMPION_SYNC_SERVER_HOSTNAME} --to http://tss:8080
     depends_on:
       mkdir:
         condition: service_completed_successfully

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,19 @@ volumes:
 
 
 services:
+  mkdir:
+    image: caddy:2-alpine
+    command: |
+      /bin/sh -c "
+      mkdir -p /data/caddy/data /data/caddy/config /data/tss/taskchampion-sync-server"
+    volumes:
+      - type: volume
+        source: data
+        target: /data
+        read_only: false
+        volume:
+          nocopy: true
+
   caddy:
     image: caddy:2-alpine
     restart: unless-stopped
@@ -24,9 +37,11 @@ services:
         volume:
           nocopy: true
           subpath: caddy/config
-    command: caddy reverse-proxy --from https://${TASKCHAMPION_SYNC_SERVER_HOSTNAME} --to http://tss:8080
+    command: caddy reverse-proxy --from http://${TASKCHAMPION_SYNC_SERVER_HOSTNAME} --to http://tss:8080
     depends_on:
-      - tss
+      mkdir:
+        condition: service_completed_successfully
+
   tss:
     image: ghcr.io/gothenburgbitfactory/taskchampion-sync-server:0.5.0
     restart: unless-stopped
@@ -42,3 +57,6 @@ services:
         volume:
           nocopy: true
           subpath: tss/taskchampion-sync-server
+    depends_on:
+      mkdir:
+        condition: service_completed_successfully

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+echo "starting entrypoint script..."
+if [ "$1" = "/bin/taskchampion-sync-server" ]; then
+    echo "setting data directories"
+    mkdir -p "/var/lib/taskchampion-sync-server/data"
+    chown -R 100:100 "/var/lib/taskchampion-sync-server/data"
+    chmod -R 700 "/var/lib/taskchampion-sync-server/data"
+    if [ "$(id -u)" = "0" ]; then
+        echo "switching to user 'taskchampion'"
+        exec su-exec taskchampion "$@"
+    fi
+fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ echo "starting entrypoint script..."
 if [ "$1" = "/bin/taskchampion-sync-server" ]; then
     echo "setting data directories"
     mkdir -p "/var/lib/taskchampion-sync-server/data"
-    chown -R 100:100 "/var/lib/taskchampion-sync-server/data"
+    chown -R 1092:1092 "/var/lib/taskchampion-sync-server/data"
     chmod -R 700 "/var/lib/taskchampion-sync-server/data"
     if [ "$(id -u)" = "0" ]; then
         echo "switching to user 'taskchampion'"


### PR DESCRIPTION
The previous docker-compose requires end user to manually handle permissions of taskchampion data dir. And this commit has directories automatically set up in docker-entrypoint.sh, just like what postgresql did in https://github.com/docker-library/postgres/blob/master/docker-entrypoint.sh

I am not sure whether you guys like this idea, please let me know what you think.

see #87