### PR TITLE
Use DATA_DIR and taskchampion username in entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,9 +3,9 @@ set -e
 echo "starting entrypoint script..."
 if [ "$1" = "/bin/taskchampion-sync-server" ]; then
     echo "setting data directories"
-    mkdir -p "/var/lib/taskchampion-sync-server/data"
-    chown -R 1092:1092 "/var/lib/taskchampion-sync-server/data"
-    chmod -R 700 "/var/lib/taskchampion-sync-server/data"
+    mkdir -p "${DATA_DIR}"
+    chown -R taskchampion:users "${DATA_DIR}"
+    chmod -R 700 "${DATA_DIR}"
     if [ "$(id -u)" = "0" ]; then
         echo "switching to user 'taskchampion'"
         exec su-exec taskchampion "$@"


### PR DESCRIPTION
In fact, there is no taskchampion group (1092 is not a defined gid). Instead taskchampion is in the `users` group.