### PR TITLE
Allow specifying client ID when running docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,13 @@ On that server, download `docker-compose.yml` from the link above (it is pinned
 to the latest release) into the current directory. Then run
 
 ```sh
-TASKCHAMPION_SYNC_SERVER_HOSTNAME=taskwarrior.example.com docker compose up
+TASKCHAMPION_SYNC_SERVER_HOSTNAME=taskwarrior.example.com \
+TASKCHAMPION_SYNC_SERVER_CLIENT_ID=your-client-id \
+docker compose up
 ```
+
+The `TASKCHAMPION_SYNC_SERVER_CLIENT_ID` limits the server to the given client
+ID; omit it to allow all client IDs.
 
 It can take a few minutes to obtain the certificate; the caddy container will
 log a message "certificate obtained successfully" when this is complete, or
@@ -56,8 +61,8 @@ your `.taskrc`'s to point to the server:
 
 ```
 sync.server.url=https://taskwarrior.example.com
-sync.server.client_id=[your client-id]
-sync.encryption_secret=[your encryption secret]
+sync.server.client_id=your-client-id
+sync.encryption_secret=your-encryption-secret
 ```
 
 The docker-compose images store data in a docker volume named
@@ -149,4 +154,12 @@ docker run -t -d \
 
 This start TaskChampion Sync-Server and publish the port to host. Please
 note that this is a basic run, all data will be destroyed after stop and
-delete container.
+delete container. You may also set `DATA_DIR`, `CLIENT_ID`, or `LISTEN` with `-e`, e.g.,
+
+```sh
+docker run -t -d \
+  --name=taskchampion \
+  -e LISTEN=0.0.0.0:9000 \
+  -p 9000:9000 \
+  taskchampion-sync-server
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - "RUST_LOG=info"
       - "DATA_DIR=/var/lib/taskchampion-sync-server/data"
       - "LISTEN=0.0.0.0:8080"
+      - "CLIENT_ID=${TASKCHAMPION_SYNC_SERVER_CLIENT_ID}"
     volumes:
       - type: volume
         source: data

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,12 +2,28 @@
 set -e
 echo "starting entrypoint script..."
 if [ "$1" = "/bin/taskchampion-sync-server" ]; then
-    echo "setting data directories"
+    : ${DATA_DIR:=/var/lib/taskchampion-sync-server}
+    export DATA_DIR
+    echo "setting up data directory ${DATA_DIR}"
     mkdir -p "${DATA_DIR}"
     chown -R taskchampion:users "${DATA_DIR}"
     chmod -R 700 "${DATA_DIR}"
+
+    : ${LISTEN:=0.0.0.0:8080}
+    export LISTEN
+    echo "Listen set to ${LISTEN}"
+
+    if [ -n "${CLIENT_ID}" ]; then
+        export CLIENT_ID
+        echo "Limiting to client ID ${CLIENT_ID}"
+    else
+        unset CLIENT_ID
+    fi
+
     if [ "$(id -u)" = "0" ]; then
-        echo "switching to user 'taskchampion'"
+        echo "Running server as user 'taskchampion'"
         exec su-exec taskchampion "$@"
     fi
+else
+    eval "${@}"
 fi


### PR DESCRIPTION
This also fixes up some handling of default values in the entrypoint.

Fixes #70.