### PR TITLE
run the security scan weekly, not daily

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,7 +2,7 @@ name: security
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '33 0 * * THU'
   push:
     paths:
       - '**/Cargo.toml'


### PR DESCRIPTION
GH was warning about disabling this workflow because the repo has been idle.