### PR TITLE
Make Storage methods async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "taskchampion-sync-server"
-version = "0.6.2-pre"
+version = "0.7.0-pre"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "taskchampion-sync-server-core"
-version = "0.6.2-pre"
+version = "0.7.0-pre"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "taskchampion-sync-server-storage-sqlite"
-version = "0.6.2-pre"
+version = "0.7.0-pre"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,11 +1599,13 @@ name = "taskchampion-sync-server-core"
 version = "0.6.2-pre"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "env_logger",
  "log",
  "pretty_assertions",
  "thiserror",
+ "tokio",
  "uuid",
 ]
 
@@ -1601,12 +1614,14 @@ name = "taskchampion-sync-server-storage-sqlite"
 version = "0.6.2-pre"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "pretty_assertions",
  "rusqlite",
  "taskchampion-sync-server-core",
  "tempfile",
  "thiserror",
+ "tokio",
  "uuid",
 ]
 
@@ -1709,7 +1724,19 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 rust-version = "1.82.0" # MSRV
 
 [workspace.dependencies]
+async-trait = "0.1.88"
 uuid = { version = "^1.17.0", features = ["serde", "v4"] }
 actix-web = "^4.11.0"
 anyhow = "1.0"
@@ -24,3 +25,4 @@ actix-rt = "2"
 tempfile = "3"
 pretty_assertions = "1"
 temp-env = "0.3"
+tokio = { version = "*", features = ["rt", "macros"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskchampion-sync-server-core"
-version = "0.6.2-pre"
+version = "0.7.0-pre"
 authors = ["Dustin J. Mitchell <dustin@mozilla.com>"]
 edition = "2021"
 description = "Core of sync protocol for TaskChampion"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 
 [dependencies]
 uuid.workspace = true
+async-trait.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 log.workspace = true
@@ -18,3 +19,4 @@ chrono.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
+tokio.workspace = true

--- a/core/src/server.rs
+++ b/core/src/server.rs
@@ -321,7 +321,10 @@ mod test {
 
         let mut version_id = Uuid::nil();
         txn.new_client(Uuid::nil()).await?;
-        debug_assert!(num_versions < u8::MAX.into());
+        assert!(
+            num_versions < u8::MAX.into(),
+            "we cast the version number to u8"
+        );
         for vnum in 0..num_versions {
             let parent_version_id = version_id;
             version_id = Uuid::new_v4();
@@ -349,22 +352,6 @@ mod test {
         txn.commit().await?;
         Ok(versions)
     }
-
-    /*
-    /// Utility setup function for add_version tests
-    async fn av_setup(
-        num_versions: u32,
-        snapshot_version: Option<u32>,
-        snapshot_days_ago: Option<i64>,
-    ) -> anyhow::Result<(Server, Uuid, Vec<Uuid>)> {
-        let (server, (client_id, versions)) = setup(async |txn, client_id| {
-
-            Ok((client_id, versions))
-        })
-        .await?;
-        Ok((server, client_id, versions))
-    }
-    */
 
     /// Utility function to check the results of an add_version call
     async fn av_success_check(

--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -44,32 +44,35 @@ pub struct Version {
 ///
 /// Changes in a transaction that is dropped without calling `commit` must not appear in any other
 /// transaction.
+#[async_trait::async_trait(?Send)]
 pub trait StorageTxn {
     /// Get information about the client for this transaction
-    fn get_client(&mut self) -> anyhow::Result<Option<Client>>;
+    async fn get_client(&mut self) -> anyhow::Result<Option<Client>>;
 
     /// Create the client for this transaction, with the given latest_version_id. The client must
     /// not already exist.
-    fn new_client(&mut self, latest_version_id: Uuid) -> anyhow::Result<()>;
+    async fn new_client(&mut self, latest_version_id: Uuid) -> anyhow::Result<()>;
 
     /// Set the client's most recent snapshot.
-    fn set_snapshot(&mut self, snapshot: Snapshot, data: Vec<u8>) -> anyhow::Result<()>;
+    async fn set_snapshot(&mut self, snapshot: Snapshot, data: Vec<u8>) -> anyhow::Result<()>;
 
     /// Get the data for the most recent snapshot.  The version_id
     /// is used to verify that the snapshot is for the correct version.
-    fn get_snapshot_data(&mut self, version_id: Uuid) -> anyhow::Result<Option<Vec<u8>>>;
+    async fn get_snapshot_data(&mut self, version_id: Uuid) -> anyhow::Result<Option<Vec<u8>>>;
 
     /// Get a version, indexed by parent version id
-    fn get_version_by_parent(&mut self, parent_version_id: Uuid)
-        -> anyhow::Result<Option<Version>>;
+    async fn get_version_by_parent(
+        &mut self,
+        parent_version_id: Uuid,
+    ) -> anyhow::Result<Option<Version>>;
 
     /// Get a version, indexed by its own version id
-    fn get_version(&mut self, version_id: Uuid) -> anyhow::Result<Option<Version>>;
+    async fn get_version(&mut self, version_id: Uuid) -> anyhow::Result<Option<Version>>;
 
     /// Add a version (that must not already exist), and
     ///  - update latest_version_id
     ///  - increment snapshot.versions_since
-    fn add_version(
+    async fn add_version(
         &mut self,
         version_id: Uuid,
         parent_version_id: Uuid,
@@ -78,12 +81,13 @@ pub trait StorageTxn {
 
     /// Commit any changes made in the transaction.  It is an error to call this more than
     /// once.  It is safe to skip this call for read-only operations.
-    fn commit(&mut self) -> anyhow::Result<()>;
+    async fn commit(&mut self) -> anyhow::Result<()>;
 }
 
 /// A trait for objects able to act as storage.  Most of the interesting behavior is in the
 /// [`crate::storage::StorageTxn`] trait.
+#[async_trait::async_trait]
 pub trait Storage: Send + Sync {
     /// Begin a transaction for the given client ID.
-    fn txn(&self, client_id: Uuid) -> anyhow::Result<Box<dyn StorageTxn + '_>>;
+    async fn txn(&self, client_id: Uuid) -> anyhow::Result<Box<dyn StorageTxn + '_>>;
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskchampion-sync-server"
-version = "0.6.2-pre"
+version = "0.7.0-pre"
 authors = ["Dustin J. Mitchell <dustin@mozilla.com>"]
 edition = "2021"
 publish = false

--- a/server/src/api/add_snapshot.rs
+++ b/server/src/api/add_snapshot.rs
@@ -49,6 +49,7 @@ pub(crate) async fn service(
     server_state
         .server
         .add_snapshot(client_id, version_id, body.to_vec())
+        .await
         .map_err(server_error_to_actix)?;
     Ok(HttpResponse::Ok().body(""))
 }
@@ -70,10 +71,10 @@ mod test {
 
         // set up the storage contents..
         {
-            let mut txn = storage.txn(client_id).unwrap();
-            txn.new_client(version_id).unwrap();
-            txn.add_version(version_id, NIL_VERSION_ID, vec![])?;
-            txn.commit()?;
+            let mut txn = storage.txn(client_id).await.unwrap();
+            txn.new_client(version_id).await.unwrap();
+            txn.add_version(version_id, NIL_VERSION_ID, vec![]).await?;
+            txn.commit().await?;
         }
 
         let server = WebServer::new(Default::default(), None, storage);
@@ -114,9 +115,9 @@ mod test {
 
         // set up the storage contents..
         {
-            let mut txn = storage.txn(client_id).unwrap();
-            txn.new_client(NIL_VERSION_ID).unwrap();
-            txn.commit().unwrap();
+            let mut txn = storage.txn(client_id).await.unwrap();
+            txn.new_client(NIL_VERSION_ID).await.unwrap();
+            txn.commit().await.unwrap();
         }
 
         let server = WebServer::new(Default::default(), None, storage);

--- a/server/src/api/get_child_version.rs
+++ b/server/src/api/get_child_version.rs
@@ -26,6 +26,7 @@ pub(crate) async fn service(
     match server_state
         .server
         .get_child_version(client_id, parent_version_id)
+        .await
     {
         Ok(GetVersionResult::Success {
             version_id,
@@ -64,11 +65,12 @@ mod test {
 
         // set up the storage contents..
         {
-            let mut txn = storage.txn(client_id).unwrap();
-            txn.new_client(Uuid::new_v4()).unwrap();
+            let mut txn = storage.txn(client_id).await.unwrap();
+            txn.new_client(Uuid::new_v4()).await.unwrap();
             txn.add_version(version_id, parent_version_id, b"abcd".to_vec())
+                .await
                 .unwrap();
-            txn.commit().unwrap();
+            txn.commit().await.unwrap();
         }
 
         let server = WebServer::new(Default::default(), None, storage);
@@ -128,11 +130,12 @@ mod test {
 
         // create the client and a single version.
         {
-            let mut txn = storage.txn(client_id).unwrap();
-            txn.new_client(Uuid::new_v4()).unwrap();
+            let mut txn = storage.txn(client_id).await.unwrap();
+            txn.new_client(Uuid::new_v4()).await.unwrap();
             txn.add_version(test_version_id, NIL_VERSION_ID, b"vers".to_vec())
+                .await
                 .unwrap();
-            txn.commit().unwrap();
+            txn.commit().await.unwrap();
         }
         let server = WebServer::new(Default::default(), None, storage);
         let app = App::new().configure(|sc| server.config(sc));

--- a/server/src/api/get_snapshot.rs
+++ b/server/src/api/get_snapshot.rs
@@ -20,6 +20,7 @@ pub(crate) async fn service(
     if let Some((version_id, data)) = server_state
         .server
         .get_snapshot(client_id)
+        .await
         .map_err(server_error_to_actix)?
     {
         Ok(HttpResponse::Ok()
@@ -48,9 +49,9 @@ mod test {
 
         // set up the storage contents..
         {
-            let mut txn = storage.txn(client_id).unwrap();
-            txn.new_client(Uuid::new_v4()).unwrap();
-            txn.commit().unwrap();
+            let mut txn = storage.txn(client_id).await.unwrap();
+            txn.new_client(Uuid::new_v4()).await.unwrap();
+            txn.commit().await.unwrap();
         }
 
         let server = WebServer::new(Default::default(), None, storage);
@@ -75,8 +76,8 @@ mod test {
 
         // set up the storage contents..
         {
-            let mut txn = storage.txn(client_id).unwrap();
-            txn.new_client(Uuid::new_v4()).unwrap();
+            let mut txn = storage.txn(client_id).await.unwrap();
+            txn.new_client(Uuid::new_v4()).await.unwrap();
             txn.set_snapshot(
                 Snapshot {
                     version_id,
@@ -85,8 +86,9 @@ mod test {
                 },
                 snapshot_data.clone(),
             )
+            .await
             .unwrap();
-            txn.commit().unwrap();
+            txn.commit().await.unwrap();
         }
 
         let server = WebServer::new(Default::default(), None, storage);

--- a/sqlite/Cargo.toml
+++ b/sqlite/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 
 [dependencies]
 taskchampion-sync-server-core = { path = "../core", version = "0.6.2-pre" }
+async-trait.workspace = true
 uuid.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
@@ -19,3 +20,4 @@ chrono.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 pretty_assertions.workspace = true
+tokio.workspace = true

--- a/sqlite/Cargo.toml
+++ b/sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskchampion-sync-server-storage-sqlite"
-version = "0.6.2-pre"
+version = "0.7.0-pre"
 authors = ["Dustin J. Mitchell <dustin@mozilla.com>"]
 edition = "2021"
 description = "SQLite backend for TaskChampion-sync-server"
@@ -9,7 +9,7 @@ repository = "https://github.com/GothenburgBitFactory/taskchampion-sync-server"
 license = "MIT"
 
 [dependencies]
-taskchampion-sync-server-core = { path = "../core", version = "0.6.2-pre" }
+taskchampion-sync-server-core = { path = "../core", version = "0.7.0-pre" }
 async-trait.workspace = true
 uuid.workspace = true
 anyhow.workspace = true

--- a/sqlite/tests/concurrency.rs
+++ b/sqlite/tests/concurrency.rs
@@ -2,45 +2,54 @@ use std::thread;
 use taskchampion_sync_server_core::{Storage, NIL_VERSION_ID};
 use taskchampion_sync_server_storage_sqlite::SqliteStorage;
 use tempfile::TempDir;
+use tokio::runtime;
 use uuid::Uuid;
 
 /// Test that calls to `add_version` from different threads maintain sequential consistency.
-#[test]
-fn add_version_concurrency() -> anyhow::Result<()> {
+///
+/// This uses `std::thread` to ensure actual parallelism, with a different, single-threaded Tokio runtime
+/// in each thread. Asynchronous concurrency does not actually test consistency.
+#[tokio::test]
+async fn add_version_concurrency() -> anyhow::Result<()> {
     let tmp_dir = TempDir::new()?;
     let client_id = Uuid::new_v4();
 
     {
         let con = SqliteStorage::new(tmp_dir.path())?;
-        let mut txn = con.txn(client_id)?;
-        txn.new_client(NIL_VERSION_ID)?;
-        txn.commit()?;
+        let mut txn = con.txn(client_id).await?;
+        txn.new_client(NIL_VERSION_ID).await?;
+        txn.commit().await?;
     }
 
     const N: i32 = 100;
     const T: i32 = 4;
 
     // Add N versions to the DB.
-    let add_versions = || {
-        let con = SqliteStorage::new(tmp_dir.path())?;
+    let add_versions = |tmp_dir, client_id| {
+        let rt = runtime::Builder::new_current_thread().build()?;
+        rt.block_on(async {
+            let con = SqliteStorage::new(tmp_dir)?;
 
-        for _ in 0..N {
-            let mut txn = con.txn(client_id)?;
-            let client = txn.get_client()?.unwrap();
-            let version_id = Uuid::new_v4();
-            let parent_version_id = client.latest_version_id;
-            std::thread::yield_now(); // Make failure more likely.
-            txn.add_version(version_id, parent_version_id, b"data".to_vec())?;
-            txn.commit()?;
-        }
+            for _ in 0..N {
+                let mut txn = con.txn(client_id).await?;
+                let client = txn.get_client().await?.unwrap();
+                let version_id = Uuid::new_v4();
+                let parent_version_id = client.latest_version_id;
+                std::thread::yield_now(); // Make failure more likely.
+                txn.add_version(version_id, parent_version_id, b"data".to_vec())
+                    .await?;
+                txn.commit().await?;
+            }
 
-        Ok::<_, anyhow::Error>(())
+            Ok::<_, anyhow::Error>(())
+        })
     };
 
     thread::scope(|s| {
         // Spawn T threads.
         for _ in 0..T {
-            s.spawn(add_versions);
+            let tmp_dir = tmp_dir.path();
+            s.spawn(move || add_versions(tmp_dir, client_id));
         }
     });
 
@@ -49,13 +58,16 @@ fn add_version_concurrency() -> anyhow::Result<()> {
     // same `parent_version_id`.
     {
         let con = SqliteStorage::new(tmp_dir.path())?;
-        let mut txn = con.txn(client_id)?;
-        let client = txn.get_client()?.unwrap();
+        let mut txn = con.txn(client_id).await?;
+        let client = txn.get_client().await?.unwrap();
 
         let mut n = 0;
         let mut version_id = client.latest_version_id;
         while version_id != NIL_VERSION_ID {
-            let version = txn.get_version(version_id)?.expect("version should exist");
+            let version = txn
+                .get_version(version_id)
+                .await?
+                .expect("version should exist");
             n += 1;
             version_id = version.parent_version_id;
         }


### PR DESCRIPTION
This will better support concurrent requests.

All of the non-test code is a straightforward transformation. The only tricky part was the tests in `core/src/server.rs`. The existing callback-based `setup` and `av_setup` functions didn't work well with async (I am not entirely sure why), so I refactored them into utility functions.

