### PR TITLE
Fix docker build invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ SQLite:
 ```sh
 docker build \
   -t taskchampion-sync-server \
-  -f Dockerfile-sqlite
+  -f Dockerfile-sqlite .
 ```
 
 Postgres:
@@ -84,7 +84,7 @@ Postgres:
 source .env
 docker build \
   -t taskchampion-sync-server-postgres \
-  -f Dockerfile-postgres
+  -f Dockerfile-postgres .
 ```
 
 Now to run it, simply exec.


### PR DESCRIPTION
Latest version of docker expects `docker build` invocations to take a single argument.

Signed-off-by: Evangelos Lamprou <vagos@lamprou.xyz>
